### PR TITLE
Поправка на звуци за оръжия в custom_weapons

### DIFF
--- a/custom_weapons.sp
+++ b/custom_weapons.sp
@@ -755,8 +755,6 @@ public OnClientConnected(client)
 	{
 		g_hTrieSounds[client][1] = CreateTrie();
 	}
-	
-	iOldCycle[client] = 0;
 }
 
 public OnClientPutInServer(client)
@@ -764,8 +762,6 @@ public OnClientPutInServer(client)
 	hPlugin[client] = INVALID_HANDLE;
 	weapon_switch[client] = INVALID_FUNCTION;
 	weapon_sequence[client] = INVALID_FUNCTION;
-	
-	iOldCycle[client] = 0;
 	
 	if (IsFakeClient(client))
 	{
@@ -792,8 +788,6 @@ public OnClientPutInServer(client)
 public OnClientPostAdminCheck(client)
 {
 	GetLanguageInfo(GetClientLanguage(client), g_sClLang[client], sizeof(g_sClLang[]));
-	
-	iOldCycle[client] = 0;
 }
 
 public OnClientCookiesCached(client)
@@ -836,8 +830,6 @@ public OnClientCookiesCached(client)
 			SetClientCookie(client, g_hCookieMenuSpawn, g_bMenuSpawn[client] ? "1" : "0");
 		}
 	}
-	
-	iOldCycle[client] = 0;
 }
 
 bool:CanSetCustomModel(client)
@@ -1741,6 +1733,7 @@ public OnPostThinkPost(client)
 
 public OnWeaponEquipPost(client, weapon)
 {
+	CSWeapon_SetPredictID(weapon, 0);
 	iDroppedModel[weapon] = 0;
 	
 	decl String:szClsname[64];
@@ -1834,6 +1827,11 @@ public OnWeaponEquipPost(client, weapon)
 	else
 	{
 		iDroppedModel[weapon] = index;
+	}
+	
+	if (index != 0)
+	{
+		CSWeapon_SetPredictID(weapon, index);
 	}
 }
 
@@ -2027,7 +2025,7 @@ bool:OnWeaponChanged(client, WeaponIndex, Sequence, bool:really_change = false)
 								{
 									if (KvGetSectionName(hKv, sSequence, sizeof(sSequence)) && sSequence[0])
 									{
-										SetTrieValue(g_hTrieSequence[client], sSequence, KvGetNum(hKv, NULL_STRING));
+										SetTrieValue(g_hTrieSequence[client], sSequence, KvGetNum(hKv, NULL_STRING, 0), true);
 									}
 								}
 								while (KvGotoNextKey(hKv, false));
@@ -2346,9 +2344,9 @@ bool:OnWeaponChanged(client, WeaponIndex, Sequence, bool:really_change = false)
 									SetTrieString(g_hTrieSounds[client][0], mapKey, soundPath, true);
 									
 									// Store sound info
-									new soundInfo[4];
+									decl any:soundInfo[4];
 									soundInfo[0] = KvGetNum(hKv, "individual", 0);
-									soundInfo[1] = _:KvGetFloat(hKv, "volume", 1.0);
+									soundInfo[1] = KvGetFloat(hKv, "volume", 1.0);
 									soundInfo[2] = KvGetNum(hKv, "level", 75);
 									soundInfo[3] = KvGetNum(hKv, "pitch", 100);
 									SetTrieArray(g_hTrieSounds[client][1], mapKey, soundInfo, 4, true);


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fix weapon sound playback issues by correcting sound sequence loading, variable declarations, and weapon prediction ID calls.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The original script had several discrepancies compared to the reference, including an omitted `true` parameter in `SetTrieValue` for sequence mapping, an incorrect array declaration for sound properties, and missing `CSWeapon_SetPredictID` calls crucial for proper weapon model and sound synchronization. Unnecessary initializations of cycle-related variables on client connection were also removed.

---
<a href="https://cursor.com/background-agent?bcId=bc-fe201eb4-353a-4af4-a2c3-925217b27463">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fe201eb4-353a-4af4-a2c3-925217b27463">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>